### PR TITLE
console.log(err) -> console.error(err)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ mg.messages.create('sandbox-123.mailgun.org', {
     html: "<h1>Testing some Mailgun awesomness!</h1>"
   })
   .then(msg => console.log(msg)) // logs response data
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 MIME Example:
@@ -124,7 +124,7 @@ mg.messages.create('sandbox-123.mailgun.org', {
     message: "<mime encoded string here>"
   })
   .then(msg => console.log(msg)) // logs response data
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Promise Returns:
@@ -166,7 +166,7 @@ Example:
 ```js
 mg.messages.list()
   .then(domains => console.log(domains)) // logs array of domains
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Promise Returns: array of Domain instances
@@ -204,7 +204,7 @@ Example:
 ```js
 mg.messages.get()
   .then(domains => console.log(domains)) // logs array of domains
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Promise Returns: Domain instance
@@ -263,7 +263,7 @@ Example:
 ```js
 mg.domains.create({name: 'foobar.example.com'})
   .then(msg => console.log(msg)) // logs response data
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Options:
@@ -330,7 +330,7 @@ Example:
 ```js
 mg.domains.destroy('foobar.example.com')
   .then(msg => console.log(msg)) // logs response data
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Promise Returns:
@@ -350,7 +350,7 @@ Example:
 ```js
 mg.domains.getTracking('foobar.example.com')
   .then(msg => console.log(msg)) // logs response data
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Promise Returns:
@@ -380,7 +380,7 @@ Open Tracking Example:
 ```js
 mg.domains.updateTracking('foobar.example.com', 'open', {active: true})
   .then(msg => console.log(msg)) // logs response data
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Open Tracking Options
@@ -405,7 +405,7 @@ Click Tracking Example:
 ```js
 mg.domains.updateTracking('foobar.example.com', 'click', {active: true})
   .then(msg => console.log(msg)) // logs response data
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Click Tracking Options
@@ -434,7 +434,7 @@ mg.domains.updateTracking('foobar.example.com', 'unsubscribe', {
     text_footer: "\n\nTo unsubscribe click: <%unsubscribe_url%>\n\n"
   })
   .then(msg => console.log(msg)) // logs response data
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Unsubscribe Tracking Options
@@ -469,7 +469,7 @@ Example:
 ```js
 mg.events.get('foobar.example.com', { page: 'mypageid' })
   .then(data => console.log(data.items)) // logs array of event objects
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Options:
@@ -549,7 +549,7 @@ Example:
 ```js
 mg.stats.getDomain('foobar.example.com', {event: ['delivered', 'accepted', 'failed', 'complained']})
   .then(msg => console.log(msg)) // logs response data
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Promise Returns:
@@ -575,7 +575,7 @@ Example:
 ```js
 mg.stats.getDomain('foobar.example.com', {event: ['delivered', 'accepted', 'failed', 'complained']})
   .then(msg => console.log(msg)) // logs response data
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Promise Returns:
@@ -603,7 +603,7 @@ Bounces Example:
 ```js
 mg.suppressions.list('foobar.example.com', 'bounces')
   .then(msg => console.log(msg)) // logs response data
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Unsubscribes Example:
@@ -611,7 +611,7 @@ Unsubscribes Example:
 ```js
 mg.suppressions.list('foobar.example.com', 'unsubscribes')
   .then(msg => console.log(msg)) // logs response data
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Complaints Example:
@@ -619,7 +619,7 @@ Complaints Example:
 ```js
 mg.suppressions.list('foobar.example.com', 'complaints')
   .then(msg => console.log(msg)) // logs response data
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Promise Returns:
@@ -653,7 +653,7 @@ Bounces Example:
 ```js
 mg.suppressions.get('foobar.example.com', 'bounces', 'address@example.com')
   .then(msg => console.log(msg)) // logs response data
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Unsubscribes Example:
@@ -661,7 +661,7 @@ Unsubscribes Example:
 ```js
 mg.suppressions.get('foobar.example.com', 'unsubscribes', 'address@example.com')
   .then(msg => console.log(msg)) // logs response data
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Complaints Example:
@@ -669,7 +669,7 @@ Complaints Example:
 ```js
 mg.suppressions.get('foobar.example.com', 'complaints', 'address@example.com')
   .then(msg => console.log(msg)) // logs response data
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Options:
@@ -694,7 +694,7 @@ Bounces Example:
 ```js
 mg.suppressions.create('foobar.example.com', 'bounces', [{address: 'bob@example.com'}])
   .then(msg => console.log(msg)) // logs response data
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Bounces Options: Contains an array with the following object properties
@@ -719,7 +719,7 @@ Unsubscribes Example:
 ```js
 mg.suppressions.create('foobar.example.com', 'unsubscribes', [{address: 'bob@example.com'}])
   .then(msg => console.log(msg)) // logs response data
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Unsubscribes Options: Contains an array with the following object properties
@@ -743,7 +743,7 @@ Complaints Example:
 ```js
 mg.suppressions.create('foobar.example.com', 'complaints', [{address: 'bob@example.com'}])
   .then(msg => console.log(msg)) // logs response data
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Complaints Options: Contains an array with the following object properties
@@ -772,7 +772,7 @@ Example:
 ```js
 mg.webhooks.list('foobar.example.com')
   .then(msg => console.log(msg)) // logs response data
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Promise Returns:
@@ -800,7 +800,7 @@ Example:
 ```js
 mg.webhooks.get('foobar.example.com', 'open') // bounce, deliver, drop, spam, unsubscribe, click, open
   .then(msg => console.log(msg)) // logs response data
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Promise Returns:
@@ -820,7 +820,7 @@ Example:
 ```js
 mg.webhooks.create('foobar.example.com', 'open', 'http://requestb.in') // bounce, deliver, drop, spam, unsubscribe, click, open
   .then(msg => console.log(msg)) // logs response data
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Promise Returns:
@@ -836,7 +836,7 @@ Test Webhook Example:
 ```js
 mg.webhooks.get('foobar.example.com', 'open', 'http://requestb.in', true) // bounce, deliver, drop, spam, unsubscribe, click, open
   .then(msg => console.log(msg)) // logs response data
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Promise Returns:
@@ -857,7 +857,7 @@ Example:
 ```js
 mg.webhooks.update('foobar.example.com', 'open', 'http://requestb.in') // bounce, deliver, drop, spam, unsubscribe, click, open
   .then(msg => console.log(msg)) // logs response data
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Promise Returns:
@@ -877,7 +877,7 @@ Example:
 ```js
 mg.webhooks.update('foobar.example.com', 'open') // bounce, deliver, drop, spam, unsubscribe, click, open
   .then(msg => console.log(msg)) // logs response data
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Promise Returns:
@@ -899,7 +899,7 @@ Example:
 ```js
 mg.routes.list()
   .then(data => console.log(data)) // logs response body
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Promise Returns: response body
@@ -926,7 +926,7 @@ Example:
 ```js
 mg.routes.get('562da483125730608a7d1719')
   .then(data => console.log(data)) // logs response body
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Promise Returns: response body
@@ -956,7 +956,7 @@ mg.routes.create({
     action: ['forward("http://myhost.com/messages/")', 'stop()']
   })
   .then(data => console.log(data)) // logs response body
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Promise Returns: response body
@@ -986,7 +986,7 @@ mg.routes.update('562da483125730608a7d1719', {
     action: ['forward("http://myhost.com/messages/")', 'stop()']
   })
   .then(data => console.log(data)) // logs response body
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Promise Returns: response body
@@ -1012,7 +1012,7 @@ Example:
 ```js
 mg.routes.destroy('562da483125730608a7d1719')
   .then(data => console.log(data)) // logs response body
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Promise Returns: response body
@@ -1035,7 +1035,7 @@ Example:
 ```js
 mg.validate.get('alice@example.com')
   .then(data => console.log(data)) // logs response body
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Promise Returns: response body
@@ -1060,7 +1060,7 @@ Example:
 ```js
 mg.parse.get('Alice <alice@example.com>, example.com', true)
   .then(data => console.log(data)) // logs response body
-  .catch(err => console.log(err)); // logs any error
+  .catch(err => console.error(err)); // logs any error
 ```
 
 Promise Returns: response body

--- a/examples/addresses.js
+++ b/examples/addresses.js
@@ -9,12 +9,12 @@ var mg = mailgun.client({
 
 mg.validate.get('Alice <alice@example.com>')
   .then(data => console.log('validate: ', data))
-  .catch(err => console.log(err));
+  .catch(err => console.error(err));
 
 mg.parse.get(['Alice <alice@example.com>', 'bob@example.com', 'example.com'])
   .then(data => console.log('parse: without dns/esp checks', data))
-  .catch(err => console.log(err));
+  .catch(err => console.error(err));
 
 mg.parse.get('Alice <alice@example.com>, bob@example.com, example.com', true)
   .then(data => console.log('parse: with dns/esp checks', data))
-  .catch(err => console.log(err));
+  .catch(err => console.error(err));

--- a/examples/index.html
+++ b/examples/index.html
@@ -239,7 +239,7 @@
             $scope.updateDomain();
             $scope.$apply();
           })
-          .catch(err => console.log(err));
+          .catch(err => console.error(err));
       };
 
       $scope.updateDomain = function(){

--- a/examples/list-domains.js
+++ b/examples/list-domains.js
@@ -5,4 +5,4 @@ var mg = mailgun.client({username: 'api', key:  process.env.MAILGUN_API_KEY || '
 
 mg.domains.list()
   .then(domains => console.log(domains))
-  .catch(err => console.log(err));
+  .catch(err => console.error(err));

--- a/examples/send-email.js
+++ b/examples/send-email.js
@@ -21,4 +21,4 @@ mg.messages.create(domain, {
     attachment: [rackspaceLogo]
   })
   .then(msg => console.log(msg))
-  .catch(err => console.log(err));
+  .catch(err => console.error(err));


### PR DESCRIPTION
Tools like Sentry and Stackdriver create new issues when `console.error` is called.
Also the browser renders them differently (they're more visible).