### PR TITLE
Upgrade Lodash dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
   "dependencies": {
     "btoa": "^1.1.2",
     "es6-promise": "^3.0.2",
-    "lodash.defaults": "^3.1.2",
+    "lodash.defaults": "^4.2.0",
     "lodash.indexby": "^3.1.1",
     "lodash.last": "^3.0.0",
-    "lodash.map": "^3.1.4",
-    "lodash.merge": "^3.3.2",
-    "lodash.partialright": "^3.1.1",
+    "lodash.map": "^4.6.0",
+    "lodash.merge": "^4.6.2",
+    "lodash.partialright": "^4.2.1",
     "popsicle": "^1.1.1",
     "popsicle-status": "^0.2.0",
     "url-join": "0.0.1"


### PR DESCRIPTION
To fix [high severity security issue in `lodash.merge`](https://github.com/lodash/lodash/pull/4336).

More info: https://snyk.io/blog/snyk-research-team-discovers-severe-prototype-pollution-security-vulnerabilities-affecting-all-versions-of-lodash/

Wasn't able to run the tests or the build locally (gave me errors), so maybe I can get some guidance whether this will break anything...