### PR TITLE
Fix: Remove legacy url package & legacy querystring API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1820,7 +1820,7 @@ Demo should be up and running at http://0.0.0.0:4001/examples/
 
 ## Requirements
 
-- Requires node.js >= 4.x
+- Requires node.js >= 12.x
 
 Install node dependencies with:
 
@@ -1837,13 +1837,13 @@ npm run build
 ## Tests
 
 ```sh
-npm run tests
+npm run test
 ```
 
 Watch tests with
 
 ```sh
-npm run watch-tests
+npm run test-watch
 ```
 
 ## Release Process

--- a/lib/interfaces/DomainTags.ts
+++ b/lib/interfaces/DomainTags.ts
@@ -238,7 +238,6 @@ export interface DomainTagDevicesAggregation {
     device: DevicesTypes;
 }
 
-
 export interface IDomainTagsClient {
     list(domain: string): Promise<DomainTagsList>
     get(domain: string, tag: string): Promise<DomainTagsItem>

--- a/lib/suppressions.ts
+++ b/lib/suppressions.ts
@@ -17,11 +17,11 @@ import {
   SuppressionList,
   SuppressionModels,
   UnsubscribeData,
-  WhiteListData
+  WhiteListData,
 } from './interfaces/Supressions';
 
 const createOptions = {
-  headers: { 'Content-Type': 'application/json' }
+  headers: { 'Content-Type': 'application/json' },
 };
 
 class Bounce implements IBounce {
@@ -80,7 +80,11 @@ class WhiteList implements IWhiteList {
   }
 }
 
-type TModel = typeof Bounce | typeof Complaint | typeof Unsubscribe | typeof WhiteList;
+type TModel =
+  | typeof Bounce
+  | typeof Complaint
+  | typeof Unsubscribe
+  | typeof WhiteList;
 
 export default class SuppressionClient {
   request: any;
@@ -101,7 +105,7 @@ export default class SuppressionClient {
     };
   }
 
-  _parsePage(id: string, pageUrl: string) : ParsedPage {
+  _parsePage(id: string, pageUrl: string): ParsedPage {
     const parsedUrl = url.parse(pageUrl, true);
     const { query } = parsedUrl;
 
@@ -109,7 +113,7 @@ export default class SuppressionClient {
       id,
       page: query.page as string,
       address: query.address as string,
-      url: pageUrl
+      url: pageUrl,
     };
   }
 
@@ -121,12 +125,14 @@ export default class SuppressionClient {
         const pageUrl = pair[1];
         acc[id] = this._parsePage(id, pageUrl);
         return acc;
-      }, {}
+      },
+      {}
     ) as unknown as ParsedPagesList;
   }
 
   _parseList(
-    response: { body: { items: any, paging: any } }, Model: TModel
+    response: { body: { items: any; paging: any } },
+    Model: TModel
   ): SuppressionList {
     const data = {} as SuppressionList;
 
@@ -150,12 +156,16 @@ export default class SuppressionClient {
       .then((response: { body: any }) => response.body);
   }
 
-  list(domain: string, type: SuppressionModels, query: any) : Promise<SuppressionList> {
-    const model = (this.models)[type];
+  list(
+    domain: string,
+    type: SuppressionModels,
+    query: any
+  ): Promise<SuppressionList> {
+    const model = this.models[type];
 
     return this.request
       .get(urljoin('v3', domain, type), query)
-      .then((response: { body: { items: any, paging: any } }) => this._parseList(response, model));
+      .then((response: { body: { items: any; paging: any } }) => this._parseList(response, model));
   }
 
   get(
@@ -163,7 +173,7 @@ export default class SuppressionClient {
     type: SuppressionModels,
     address: string
   ): Promise<IBounce | IComplaint | IUnsubscribe | IWhiteList> {
-    const model = (this.models)[type];
+    const model = this.models[type];
 
     return this.request
       .get(urljoin('v3', domain, type, encodeURIComponent(address)))
@@ -184,7 +194,11 @@ export default class SuppressionClient {
     }
 
     return this.request
-      .post(urljoin('v3', domain, type), JSON.stringify(postData), createOptions)
+      .post(
+        urljoin('v3', domain, type),
+        JSON.stringify(postData),
+        createOptions
+      )
       .then((response: { body: any }) => response.body);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5842,21 +5842,11 @@
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
-    "punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
-    },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -7019,15 +7009,6 @@
           "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
           "dev": true
         }
-      }
-    },
-    "url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
       }
     },
     "url-join": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "bluebird": "^3.7.2",
     "ky": "^0.25.1",
     "ky-universal": "^0.8.2",
-    "url": "^0.11.0",
     "url-join": "0.0.1",
     "web-streams-polyfill": "^3.0.1",
     "webpack-merge": "^5.4.0"


### PR DESCRIPTION
## Summary

While installing `mailgun.js` with Node 12, I ran into this warning:
```
mailgun.js > url > querystring@0.2.0: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
```

I thought it was the occasion to get rid of `url` package to rely on modern APIs, as the supported Node version is 12.

I also updated REAME with correct tips.