### PR TITLE
fix: Remove invalid `StatsEvent` types

### DIFF
--- a/dist/mailgun.js.d.ts
+++ b/dist/mailgun.js.d.ts
@@ -1217,7 +1217,7 @@ declare module 'mailgun.js/interfaces/StatsOptions' {
         resolution: string;
         stats: Stat[];
     }
-    export type StatsEvent = 'accepted' | 'delivered' | 'opened' | 'clicked' | 'unsubscribed' | 'stored' | 'rejected' | 'complained' | 'failed-temporary' | 'failed-permanent';
+    export type StatsEvent = 'accepted' | 'delivered' | 'opened' | 'clicked' | 'unsubscribed' | 'stored' | 'complained' | 'failed';
     export interface StatsQuery {
         event: StatsEvent | StatsEvent[];
         start?: string | Date;

--- a/lib/interfaces/StatsOptions.ts
+++ b/lib/interfaces/StatsOptions.ts
@@ -14,7 +14,7 @@ export interface StatsOptions {
   stats: Stat[];
 }
 
-export type StatsEvent = 'accepted' | 'delivered' | 'opened' | 'clicked' | 'unsubscribed' | 'stored' | 'rejected' | 'complained' | 'failed-temporary' | 'failed-permanent';
+export type StatsEvent = 'accepted' | 'delivered' | 'opened' | 'clicked' | 'unsubscribed' | 'stored' | 'complained' | 'failed';
 
 export interface StatsQuery {
   event: StatsEvent | StatsEvent[];


### PR DESCRIPTION
Did not do enough testing before submitting #248 -- `rejected`,  `failed-temporary`, `failed-permanent` are not valid options and get rejected by the API