### PR TITLE
Update testmode in messages to correctly match API

### DIFF
--- a/lib/interfaces/Messages.ts
+++ b/lib/interfaces/Messages.ts
@@ -131,9 +131,9 @@ export type MailgunMessageData = MailgunMessageContent & {
     'o:time-zone-localize'?: string;
 
     /**
-     * Enables sending in test mode. Pass `yes` if needed. See [Sending in Test Mode](https://documentation.mailgun.com/en/latest/user_manual.html#manual-testmode)
+     * Enables sending in test mode. Pass `true` if needed. See [Sending in Test Mode](https://documentation.mailgun.com/en/latest/user_manual.html#manual-testmode)
      */
-    'o:testmode'?: boolean | 'yes' | 'no';
+    'o:testmode'?: 'true' | 'false';
 
     /**
      * Toggles tracking on a per-message basis, see [Tracking Messages](https://documentation.mailgun.com/en/latest/user_manual.html#tracking-messages for details. Pass 'yes', 'no', 'true' or 'false'


### PR DESCRIPTION
'o:testmode' via API does not accept a boolean value, a string 'yes', or a string 'no'. Correctly tested (on my side) with string 'true' and 'false'

also note, this is also wrong: https://documentation.mailgun.com/en/latest/user_manual.html#manual-testmode, 