### PR TITLE
fix(types): Clarify DomainTemplatesQuery properties

### DIFF
--- a/lib/interfaces/DomainTemplates.ts
+++ b/lib/interfaces/DomainTemplates.ts
@@ -35,8 +35,12 @@ export type DomainTemplateUpdateVersionData = {
 }
 
 export type DomainTemplatesQuery = {
-    page: 'string';
-    limit: number;
+    /** 'page' (optionally 'p') params from previous response's 'paging' object.
+     * Value must be stringified as query params. Ex: '?page=first','?page=next&p=name-of-last-item'
+     .... */
+    page?: `?${string}`;
+    /** Number of records to retrieve. Default value is 10. */
+    limit?: number;
 }
 
 export type TemplateQuery = {

--- a/test/domainsTemplates.test.ts
+++ b/test/domainsTemplates.test.ts
@@ -67,6 +67,43 @@ describe('DomainsTemplatesClient', function () {
       templatesList.pages.previous.page.should.be.equal('?page=previous&p=temporary-test-template&limit=10');
       expect(templatesList.pages.next.iteratorPosition).to.be.equal('temporary-test-template');
     });
+
+    it('fetches pages of templates with the "page" and "limit" options', async () => {
+      api.get('/v3/testDomain/templates?page=next&p=temporary-test-template&limit=1').reply(200, {
+        items: [
+          {
+            name: 'test_template',
+            description: 'test_template description',
+            createdAt: 'Mon, 20 Dec 2021 14:47:51 UTC',
+            createdBy: '',
+            id: 'someId',
+          },
+        ],
+        paging: {
+          first: 'https://api.mailgun.net/v3/testDomain/templates?limit=1',
+          last: 'https://api.mailgun.net/v3/testDomain/templates?page=last&limit=1',
+          next: 'https://api.mailgun.net/v3/testDomain/templates?page=next&p=temporary-test-template&limit=1',
+          previous: 'https://api.mailgun.net/v3/testDomain/templates?page=previous&p=temporary-test-template&limit=1',
+        },
+      });
+
+      const templatesList = await client.list('testDomain', {
+        page: '?page=next&p=temporary-test-template',
+        limit: 1,
+      });
+      templatesList.should.be.an('object').to.have.property('items');
+      templatesList.pages.first.page.should.be.equal('?limit=1');
+      expect(templatesList.pages.first.iteratorPosition).to.be.equal(undefined);
+
+      templatesList.pages.last.page.should.be.equal('?page=last&limit=1');
+      expect(templatesList.pages.last.iteratorPosition).to.be.equal(undefined);
+
+      templatesList.pages.next.page.should.be.equal('?page=next&p=temporary-test-template&limit=1');
+      expect(templatesList.pages.next.iteratorPosition).to.be.equal('temporary-test-template');
+
+      templatesList.pages.previous.page.should.be.equal('?page=previous&p=temporary-test-template&limit=1');
+      expect(templatesList.pages.next.iteratorPosition).to.be.equal('temporary-test-template');
+    });
   });
 
   describe('get', function () {


### PR DESCRIPTION
Resolves #310 

Update `DomainTemplatesQuery` interface
- `page` and `limit` are now optional
- Add type descriptions for editor hints 
- `page` typed as `?${string}`

### Description

This type update prevents devs from passing an incorrect `page` option arg to the `.list()` methods:
#### Incorrect Usage
```typescript
const templatesList = await mg.domains.domainTemplates.list('testDomain', {
  page: 'first',
 });

// Results in bad URL 
// https://api.mailgun.net/v3/testDomain/templates/first
// 404
```
#### Correct Usage
```typescript
const templatesList = await mg.domains.domainTemplates.list('testDomain', {
  page: '?page=first',
 });

// -> https://api.mailgun.net/v3/testDomain/templates?page=first
```


#### Usage description in editor
<img width="695" alt="image" src="https://user-images.githubusercontent.com/9354822/192054591-7f9ddd76-608b-4357-b3ae-5492133790f4.png">

#### New type error
<img width="649" alt="image" src="https://user-images.githubusercontent.com/9354822/192054754-8748997a-a2df-4a7c-ad30-d46a5711d63b.png">

I included the `"?"` prefix on the type to guide dev