### PR TITLE
added priority (optional) to DNSRecord interface

### DIFF
--- a/lib/interfaces/Domains.ts
+++ b/lib/interfaces/Domains.ts
@@ -49,6 +49,7 @@ export interface DNSRecord {
     record_type: string;
     valid: string;
     value: string;
+    priority?: string;
 }
 
 export type DomainResponseData = {


### PR DESCRIPTION
The response from creating the domain gives the required verification DNS records. The receiving DNS records have a priority section in the MX record part. This is not there for sending DNS records. Hence, added priority as an optional element in the DNSRecord interface