### PR TITLE
fix: Corrected WebhooksIds - unsubscribed

### DIFF
--- a/lib/Enums/index.ts
+++ b/lib/Enums/index.ts
@@ -18,7 +18,7 @@ export enum WebhooksIds {
     OPENED = 'opened',
     PERMANENT_FAIL = 'permanent_fail',
     TEMPORARY_FAIL = 'temporary_fail',
-    UNSUBSCRIBED = 'unsubscribe',
+    UNSUBSCRIBED = 'unsubscribed',
 }
 
 export enum YesNo {


### PR DESCRIPTION
The correct value is unsubscribed and not unsubscribe
https://documentation.mailgun.com/en/latest/api-webhooks.html#webhooks

Fixed as per the documentation