### PR TITLE
Fix import FormData example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Once the package is installed, you can import the library using `import` or `req
   const mg = mailgun.client({username: 'api', key: process.env.MAILGUN_API_KEY || 'key-yourkeyhere'});
 ```
 ```js
-  import * as FormData from 'form-data';
+  import FormData from 'form-data';
   import Mailgun from 'mailgun.js';
   const mailgun = new Mailgun(FormData);
   const mg = mailgun.client({username: 'api', key: process.env.MAILGUN_API_KEY || 'key-yourkeyhere'});
@@ -62,7 +62,7 @@ Once the package is installed, you can import the library using `import` or `req
 ### Using Subaccounts
 Primary accounts can make API calls on behalf of their subaccounts. [API documentation](https://documentation.mailgun.com/en/latest/subaccounts.html#subaccounts)
 ```js
-  import * as FormData from 'form-data';
+  import FormData from 'form-data';
   import Mailgun from 'mailgun.js';
   const mailgun = new Mailgun(FormData);
   const mg = mailgun.client({username: 'api', key: process.env.MAILGUN_API_KEY || 'key-yourkeyhere'});
@@ -75,7 +75,7 @@ Primary accounts can make API calls on behalf of their subaccounts. [API documen
 By leveraging client configuration options, users can effortlessly establish proxy connections that align with their network requirements.
 Ex:
 ```js
-  import * as FormData from 'form-data';
+  import FormData from 'form-data';
   import Mailgun from 'mailgun.js';
   const mailgun = new Mailgun(FormData);
 


### PR DESCRIPTION
Changed:
import * as FormData from 'form-data';

To:
import FormData from 'form-data';

To resolve the issue: 
"TypeError: this.FormDataConstructor is not a constructor at e.createFormData ..."