### PR TITLE
fix: Corrected lack of optional parameters for creating multiple mailing list members

### DIFF
--- a/lib/Types/MailingLists/MailingListMembers.ts
+++ b/lib/Types/MailingLists/MailingListMembers.ts
@@ -16,8 +16,15 @@ export type MailListMembersQuery = {
     page?: string;
 }
 
+export type CreateMultipleMailListMembers = Array<{
+    address: string;
+    name?: string;
+    vars?: string;
+    subscribed?: boolean;
+}>
+
 export type MultipleMembersData = {
-    members: Array<MailListMember>;
+    members: CreateMultipleMailListMembers;
     upsert: 'yes' | 'no';
 }
 


### PR DESCRIPTION
Hello,

I encountered an issue while integrating this SDK into our project. Our mailing lists only store email addresses and ignore the other optional parameters defined in the `CreateUpdateMailListMembers` type:

```typescript
type CreateUpdateMailListMembers = {
    address: string;
    name?: string;
    vars?: string;
    subscribed?: 'yes' | 'no' | boolean;
    upsert?: 'yes' | 'no';
}
 ```

However, the` IMailListsMembers.createMembers` method requires the `members` parameter to use the `MailListMember` type, which mandates all properties:

```typescript
type MailListMember = {
    address: string;
    name: string;
    subscribed: boolean,
    vars: {
        [key: string]: unknown
    };
}
 ```
Our temporary workaround was to cast the parameter to `any`, but we don't like that :P
```typescript
return await client.lists.members.createMembers(listAddress, {
      members: members.map(
        (address) =>
          ({
            address,
            // This cast was made because of an error on the Mailgun SDK typing that makes some MailListMember optional properties obligatory.
          }) as any,
      ),
      upsert: 'yes',
    });
 ```
To resolve this cleanly, I created a new type for `IMailListsMembers.createMembers` that makes these properties optional. Although I considered using the existing `CreateUpdateMailListMembers` with `Omit<>` to remove the `upsert` field, a new type looks clearer and simpler for casting:
```typescript
export type CreateMultipleMailListMembers = Array<{
    address: string;
    name?: string;
    vars?: string;
    subscribed?: boolean;
}>
 ```